### PR TITLE
chore: fix typo `depndency` → `dependency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [depm] -- Visualize depndency packages and modules
+# [depm] -- Visualize dependency packages and modules
 
 [![check vulns](https://github.com/goark/depm/workflows/vulns/badge.svg)](https://github.com/goark/depm/actions)
 [![lint status](https://github.com/goark/depm/workflows/lint/badge.svg)](https://github.com/goark/depm/actions)
@@ -23,7 +23,7 @@ See [latest release](https://github.com/goark/depm/releases/latest).
 
 ```
 $ depm -h
-Visualize depndency packages and modules.
+Visualize dependency packages and modules.
 
 Usage:
   depm [flags]
@@ -33,8 +33,8 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   list        list modules
-  module      analyze depndency modules
-  package     analyze depndency packages
+  module      analyze dependency modules
+  package     analyze dependency packages
   version     print the version number
 
 Flags:
@@ -47,11 +47,11 @@ Flags:
 Use "depm [command] --help" for more information about a command.
 ```
 
-### Analyze Depndency Packages
+### Analyze dependency Packages
 
 ```
 $ depm package -h
-analyze depndency packages.
+analyze dependency packages.
 
 Usage:
   depm package [flags] [package import path]
@@ -98,11 +98,11 @@ $ depm package | jq .
 ...
 ```
 
-### Analyze Depndency Modules
+### Analyze dependency Modules
 
 ```
 $ depm module -h
-analyze depndency modules.
+analyze dependency modules.
 
 Usage:
   depm module [flags] [package import path]
@@ -207,4 +207,4 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 
 [![dependency.png](./dependency.png)](./dependency.png)
 
-[depm]: https://github.com/goark/depm "goark/depm: Visualize depndency packages and modules"
+[depm]: https://github.com/goark/depm "goark/depm: Visualize dependency packages and modules"

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -27,8 +27,8 @@ var (
 func newRootCmd(ui *rwi.RWI, args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   Name,
-		Short: "Visualize depndency packages and modules",
-		Long:  "Visualize depndency packages and modules.",
+		Short: "Visualize dependency packages and modules",
+		Long:  "Visualize dependency packages and modules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return debugPrint(ui, errs.Wrap(ecode.ErrNoCommand))
 		},

--- a/facade/module.go
+++ b/facade/module.go
@@ -20,8 +20,8 @@ func newModuleCmd(ui *rwi.RWI) *cobra.Command {
 	moduleCmd := &cobra.Command{
 		Use:     "module [flags] [package import path]",
 		Aliases: []string{"mod", "m"},
-		Short:   "analyze depndency modules",
-		Long:    "analyze depndency modules.",
+		Short:   "analyze dependency modules",
+		Long:    "analyze dependency modules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//Options
 			dotFlag, err := cmd.Flags().GetBool("dot")

--- a/facade/package.go
+++ b/facade/package.go
@@ -20,8 +20,8 @@ func newPackageCmd(ui *rwi.RWI) *cobra.Command {
 	packageCmd := &cobra.Command{
 		Use:     "package [flags] [package import path]",
 		Aliases: []string{"pkg", "p"},
-		Short:   "analyze depndency packages",
-		Long:    "analyze depndency packages.",
+		Short:   "analyze dependency packages",
+		Long:    "analyze dependency packages.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//Options
 			dotFlag, err := cmd.Flags().GetBool("dot")


### PR DESCRIPTION
## Summary

Correct spelling of "dependency" across user-facing documentation and CLI help text.

Enhancements:
- Fix spelling of "dependency" in CLI command descriptions for root, module, and package commands.

Documentation:
- Fix spelling of "dependency" in README headings, descriptions, examples, and link title.

> [!NOTE]
> Could you also update the description in GitHub About?
> <img width="228" height="82" alt="image" src="https://github.com/user-attachments/assets/ef54f0d1-163a-44bd-807b-133c0f3c9888" />
